### PR TITLE
Update 6.memory-level-parameters.md

### DIFF
--- a/zh-CN/4.user-guide/1.configuration/6.memory-level-parameters.md
+++ b/zh-CN/4.user-guide/1.configuration/6.memory-level-parameters.md
@@ -4,7 +4,7 @@
 
 |          **参数**           | **默认值** |             **说明**              |
 |---------------------------|---------|---------------------------------|
-| **`refresh_json_config`** | false   | 重新从 config server 获取 json 配置。   |
-| **`refresh_rslist`**      | false   | 重新从 config server 获取 rslist 配置。 |
-| **`refresh_idc_list`**    | false   | 重新从 config server 获取 idc 配置。    |
-| **`refresh_config`**      | false   | 重新从 MetaDB 更新所有配置。              |
+| refresh_json_config | false   | 重新从 config server 获取 json 配置。   |
+| refresh_rslist      | false   | 重新从 config server 获取 rslist 配置。 |
+| refresh_idc_list    | false   | 重新从 config server 获取 idc 配置。    |
+| refresh_config      | false   | 重新从 MetaDB 更新所有配置。             |


### PR DESCRIPTION
依据文档书写规范，表格里的参数名统一不加格式。